### PR TITLE
Improve xargs command

### DIFF
--- a/command_builder.test.ts
+++ b/command_builder.test.ts
@@ -11,6 +11,6 @@ Deno.test("Quick example", async () => {
   }
 
   const result = await $`echo hello`
-    .xargs((input) => $`echo ${input} world`);
+    .xargs((input) => $`echo ${input} world`.stdout("piped"));
   assertEquals(result[0].stdout, "hello world\n");
 });

--- a/command_builder.test.ts
+++ b/command_builder.test.ts
@@ -9,4 +9,8 @@ Deno.test("Quick example", async () => {
   for await (const line of stream) {
     assertEquals(line, "bug : abcdef");
   }
+
+  const result = await $`echo hello`
+    .xargs((input) => $`echo ${input} world`);
+  assertEquals(result[0].stdout, "hello world\n");
 });

--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,6 @@
 export { $, CommandBuilder } from "https://deno.land/x/dax@0.32.0/mod.ts";
-export { CommandChild } from "https://deno.land/x/dax@0.32.0/src/command.ts";
+export {
+  CommandChild,
+  CommandResult,
+} from "https://deno.land/x/dax@0.32.0/src/command.ts";
 export { TextLineStream } from "https://deno.land/std@0.182.0/streams/text_line_stream.ts";

--- a/linestream/linestream.ts
+++ b/linestream/linestream.ts
@@ -1,4 +1,4 @@
-import { CommandBuilder, CommandChild } from "../deps.ts";
+import { CommandBuilder, CommandChild, CommandResult } from "../deps.ts";
 
 import {
   FilterFunction,
@@ -56,11 +56,11 @@ export class LineStream {
   filter(filterFunction: FilterFunction<string>): LineStream {
     return this.pipeThrough(new FilterStream(filterFunction));
   }
-  async xargs(command: XargsFunction): Promise<CommandChild[]> {
+  async xargs(command: XargsFunction): Promise<CommandResult[]> {
     const processes: CommandChild[] = [];
     for await (const line of this.stream) {
-      processes.push(command(line).spawn());
+      processes.push(command(line).stdout("piped").spawn());
     }
-    return processes;
+    return await Promise.all(processes);
   }
 }

--- a/linestream/linestream.ts
+++ b/linestream/linestream.ts
@@ -59,7 +59,7 @@ export class LineStream {
   async xargs(command: XargsFunction): Promise<CommandResult[]> {
     const processes: CommandChild[] = [];
     for await (const line of this.stream) {
-      processes.push(command(line).stdout("piped").spawn());
+      processes.push(command(line).spawn());
     }
     return await Promise.all(processes);
   }

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { $, CommandBuilder, CommandChild, TextLineStream } from "./deps.ts";
+import { $, CommandBuilder, CommandResult, TextLineStream } from "./deps.ts";
 
 import { FilterFunction, MapFunction } from "./linestream/transformer.ts";
 import { LineStream, XargsFunction } from "./linestream/linestream.ts";
@@ -10,7 +10,7 @@ declare module "./deps.ts" {
     $(next: string): CommandBuilder;
     map(mapFunction: MapFunction<string, string>): LineStream;
     filter(filterFunction: FilterFunction<string>): LineStream;
-    xargs(xargsFunction: XargsFunction): Promise<CommandChild[]>;
+    xargs(xargsFunction: XargsFunction): Promise<CommandResult[]>;
   }
 }
 


### PR DESCRIPTION
wait for CommandChild to finish so we can return
CommandResult
This is more useful for the user, since it has things like .stdout .stderr that returns the result as a string

also add a test to make sure this actually works

In theory xargs should really chain like the other methods so we can use .xargs.pipe.xargs, hopefully we can figure this out