### PR TITLE
rework external api

### DIFF
--- a/LineStream/LineStream.test.ts
+++ b/LineStream/LineStream.test.ts
@@ -1,5 +1,8 @@
-import $ from "../mod.ts";
+import { $, CommandBuilder } from "../deps.ts";
+import { addExtras, SUPPORTED_VERSION } from "../mod.ts";
 import { assertEquals } from "../test_deps.ts";
+
+addExtras(CommandBuilder, SUPPORTED_VERSION);
 
 Deno.test("LineStream.text", async () => {
   const text = await $`echo "line1\nline2"`

--- a/LineStream/LineStream.test.ts
+++ b/LineStream/LineStream.test.ts
@@ -1,8 +1,8 @@
 import { $, CommandBuilder } from "../deps.ts";
-import { addExtras, SUPPORTED_VERSION } from "../mod.ts";
+import { addExtras } from "../mod.ts";
 import { assertEquals } from "../test_deps.ts";
 
-addExtras(CommandBuilder, SUPPORTED_VERSION);
+addExtras(CommandBuilder, "0.32.0");
 
 Deno.test("LineStream.text", async () => {
   const text = await $`echo "line1\nline2"`

--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@ A useful util library for writing shell script stream processing using
 ## Quick example
 
 ```typescript
-import {$, CommandBuilder} from "https://deno.land/x/dax@0.32.0/mod.ts";
-import {addExtras} "https://raw.githubusercontent.com/impactaky/dax_extras/1.0.0/mod.ts";
+import { $, CommandBuilder } from "https://deno.land/x/dax@0.32.0/mod.ts";
+import { addExtras } from "./mod.ts";
 
-addExtras(CommandBuilder, /*dax version*/ "0.32.0")
+addExtras(CommandBuilder, /*dax version*/ "0.32.0");
 
-await $`echo "abc\nabcde\nabcdef\nbcdefg"`
+const commands = await $`echo "abc\nabcde\nabcdef\nbcdefg"`
   .map((l) => `bug : ${l}`)
   .$(`grep 'bug : a'`).noThrow()
   .filter((l) => l.length > "bug : ".length + 3)
   .xargs((l) => $`echo de${l}`);
+await Promise.all(commands);
 // => debug : abcde
 // => debug : abcdef
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ A useful util library for writing shell script stream processing using
 ## Quick example
 
 ```typescript
-import $ from "https://raw.githubusercontent.com/impactaky/dax_extras/1.0.0/mod.ts";
+import {$, CommandBuilder} from "https://deno.land/x/dax@0.32.0/mod.ts";
+import {addExtras} "https://raw.githubusercontent.com/impactaky/dax_extras/1.0.0/mod.ts";
+
+addExtras(CommandBuilder, /*dax version*/ "0.32.0")
 
 await $`echo "abc\nabcde\nabcdef\nbcdefg"`
   .map((l) => `bug : ${l}`)
@@ -15,15 +18,4 @@ await $`echo "abc\nabcde\nabcdef\nbcdefg"`
   .xargs((l) => $`echo de${l}`);
 // => debug : abcde
 // => debug : abcdef
-```
-
-## Usage
-
-### Use with your dax extends
-
-You can import dax_extras like this.
-
-```typescript
-import $ from "https://deno.land/x/dax@0.32.0/mod.ts";
-import "https://raw.githubusercontent.com/impactaky/dax_extras/1.0.0/mod.ts";
 ```

--- a/command_builder.test.ts
+++ b/command_builder.test.ts
@@ -1,8 +1,8 @@
 import { assertEquals } from "./test_deps.ts";
 import { $, CommandBuilder } from "./deps.ts";
-import { addExtras, SUPPORTED_VERSION } from "./mod.ts";
+import { addExtras } from "./mod.ts";
 
-addExtras(CommandBuilder, SUPPORTED_VERSION);
+addExtras(CommandBuilder, "0.32.0");
 
 Deno.test("Quick example", async () => {
   const stream = $`echo "abc\nabcde\nabcdef\nacddef\nbcdefg"`

--- a/command_builder.test.ts
+++ b/command_builder.test.ts
@@ -1,5 +1,8 @@
-import $ from "./mod.ts";
 import { assertEquals } from "./test_deps.ts";
+import { $, CommandBuilder } from "./deps.ts";
+import { addExtras, SUPPORTED_VERSION } from "./mod.ts";
+
+addExtras(CommandBuilder, SUPPORTED_VERSION);
 
 Deno.test("Quick example", async () => {
   const stream = $`echo "abc\nabcde\nabcdef\nacddef\nbcdefg"`


### PR DESCRIPTION
fix https://github.com/impactaky/dax_extras/issues/2

The api now looks like this
```ts
import { $, CommandBuilder } from "https://deno.land/x/dax@0.32.0/mod.ts";
import { addExtras } from "./mod.ts";

addExtras(CommandBuilder, "0.32.0");

// $ have now the extra functions
```