### PR TITLE
Refactor codebase

### DIFF
--- a/LineStream/LineStream.test.ts
+++ b/LineStream/LineStream.test.ts
@@ -21,6 +21,14 @@ Deno.test("LineStream.$", async () => {
   assertEquals(text, ["line1", "line2"]);
 });
 
+Deno.test("LineStream.pipe", async () => {
+  const text = await $`echo "line1\nline2"`
+    .lineStream()
+    .pipe($`cat`)
+    .lines();
+  assertEquals(text, ["line1", "line2"]);
+});
+
 Deno.test("LineStream.map", async () => {
   const text = await $`echo "line1\nline2"`
     .lineStream()

--- a/LineStream/LineStream.ts
+++ b/LineStream/LineStream.ts
@@ -28,15 +28,27 @@ class LineToByteStream extends TransformStream<string, Uint8Array> {
   }
 }
 
+/**
+ * Represents a stream of lines for reading the output of a command.
+ * It implements an async iterator, allowing iteration over the lines.
+ */
 export class LineStream {
-  stream: ReadableStream;
+  #stream: ReadableStream;
 
+  /**
+   * Constructs a new `LineStream` with the provided readable stream.
+   * @param stream - The readable stream to create the line stream from.
+   */
   constructor(stream: ReadableStream) {
-    this.stream = stream;
+    this.#stream = stream;
   }
 
+  /**
+   * Async iterator implementation for iterating over the lines of the stream.
+   * @returns An async iterator for iterating over the lines of the stream.
+   */
   async *[Symbol.asyncIterator]() {
-    const reader = this.stream.getReader();
+    const reader = this.#stream.getReader();
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
@@ -44,47 +56,87 @@ export class LineStream {
     }
   }
 
+  /**
+   * Reads the entire stream and returns the concatenated text.
+   * @returns A promise that resolves to the concatenated text.
+   */
   async text(): Promise<string> {
     let text = "";
-    for await (const line of this.stream) {
+    for await (const line of this.#stream) {
       text += line + "\n";
     }
     return text;
   }
 
+  /**
+   * Reads the stream and returns an array of lines.
+   * @returns A promise that resolves to an array of lines.
+   */
   async lines(): Promise<string[]> {
     const lines: string[] = [];
-    for await (const line of this.stream) {
+    for await (const line of this.#stream) {
       lines.push(line);
     }
     return lines;
   }
 
+  /**
+   * Pipes the stream through a transform stream.
+   * @param transform - The transform stream to pipe the line stream through.
+   * @returns A new line stream representing the piped stream.
+   */
   pipeThrough(transform: TransformStream): LineStream {
-    return new LineStream(this.stream.pipeThrough(transform));
+    return new LineStream(this.#stream.pipeThrough(transform));
   }
 
+  /**
+   * Pipes a command into the stdin of the next command in the chain.
+   * @param next - The command builder representing the next command.
+   * @returns The command builder with the stdin piped from the current stream.
+   */
   pipe(next: CommandBuilder): CommandBuilder {
-    const pipedStream = this.stream.pipeThrough(new LineToByteStream());
+    const pipedStream = this.#stream.pipeThrough(new LineToByteStream());
     return next.stdin(pipedStream);
   }
 
+  /**
+   * Pipes a command into the stdin of the next command in the chain.
+   * @param next - The command as a string to pipe into.
+   * @returns The command builder with the stdin piped from the current stream.
+   */
   $(next: string): CommandBuilder {
-    const pipedStream = this.stream.pipeThrough(new LineToByteStream());
+    const pipedStream = this.#stream.pipeThrough(new LineToByteStream());
     return new CommandBuilder().command(next).stdin(pipedStream);
   }
 
+  /**
+   * Maps the stream using a map function, allowing further processing.
+   * @param mapFunction - The function to map theoutput of each line.
+   *
+   * @param mapFunction - The function to map the output of each line.
+   * @returns A new line stream resulting from the mapping operation.
+   */
   map(mapFunction: MapFunction<string, string>): LineStream {
     return this.pipeThrough(new MapStream(mapFunction));
   }
 
+  /**
+   * Filters the stream using a filter function, allowing further processing.
+   * @param filterFunction - The function to filter the output of each line.
+   * @returns A new line stream resulting from the filtering operation.
+   */
   filter(filterFunction: FilterFunction<string>): LineStream {
     return this.pipeThrough(new FilterStream(filterFunction));
   }
 
+  /**
+   * Executes a command for each line of the stream using the provided xargs function.
+   * @param command - The xargs function that handles the execution of command lines.
+   * @returns A promise that resolves to an array of command builders representing the executed commands.
+   */
   async xargs(command: XargsFunction): Promise<CommandBuilder[]> {
     const processes: CommandBuilder[] = [];
-    for await (const line of this.stream) {
+    for await (const line of this.#stream) {
       processes.push(command(line));
     }
     return processes;

--- a/LineStream/LineStream.ts
+++ b/LineStream/LineStream.ts
@@ -135,7 +135,7 @@ export class LineStream {
   async xargs(xargsFunction: XargsFunction): Promise<CommandBuilder[]> {
     const processes: CommandBuilder[] = [];
     for await (const line of this.#stream) {
-      processes.push(command(line));
+      processes.push(xargsFunction(line));
     }
     return processes;
   }

--- a/LineStream/LineStream.ts
+++ b/LineStream/LineStream.ts
@@ -129,10 +129,10 @@ export class LineStream {
 
   /**
    * Executes a command for each line of the stream using the provided xargs function.
-   * @param command - The xargs function that handles the execution of command lines.
+   * @param xargsFunction - The xargs function that handles the execution of command lines.
    * @returns A promise that resolves to an array of CommandBuilders representing the executed commands.
    */
-  async xargs(command: XargsFunction): Promise<CommandBuilder[]> {
+  async xargs(xargsFunction: XargsFunction): Promise<CommandBuilder[]> {
     const processes: CommandBuilder[] = [];
     for await (const line of this.#stream) {
       processes.push(command(line));

--- a/LineStream/LineStream.ts
+++ b/LineStream/LineStream.ts
@@ -69,7 +69,7 @@ export class LineStream {
   }
 
   /**
-   * Reads the stream and returns an array of lines.
+   * Reads the entire stream and returns an array of lines.
    * @returns A promise that resolves to an array of lines.
    */
   async lines(): Promise<string[]> {
@@ -91,8 +91,8 @@ export class LineStream {
 
   /**
    * Pipes a command into the stdin of the next command in the chain.
-   * @param next - The command builder representing the next command.
-   * @returns The command builder with the stdin piped from the current stream.
+   * @param next - The CommandBuilder representing the next command.
+   * @returns The CommandBuilder with the stdin piped from the current stream.
    */
   pipe(next: CommandBuilder): CommandBuilder {
     const pipedStream = this.#stream.pipeThrough(new LineToByteStream());
@@ -102,7 +102,7 @@ export class LineStream {
   /**
    * Pipes a command into the stdin of the next command in the chain.
    * @param next - The command as a string to pipe into.
-   * @returns The command builder with the stdin piped from the current stream.
+   * @returns The CommandBuilder with the stdin piped from the current stream.
    */
   $(next: string): CommandBuilder {
     const pipedStream = this.#stream.pipeThrough(new LineToByteStream());
@@ -111,8 +111,6 @@ export class LineStream {
 
   /**
    * Maps the stream using a map function, allowing further processing.
-   * @param mapFunction - The function to map theoutput of each line.
-   *
    * @param mapFunction - The function to map the output of each line.
    * @returns A new line stream resulting from the mapping operation.
    */
@@ -132,7 +130,7 @@ export class LineStream {
   /**
    * Executes a command for each line of the stream using the provided xargs function.
    * @param command - The xargs function that handles the execution of command lines.
-   * @returns A promise that resolves to an array of command builders representing the executed commands.
+   * @returns A promise that resolves to an array of CommandBuilders representing the executed commands.
    */
   async xargs(command: XargsFunction): Promise<CommandBuilder[]> {
     const processes: CommandBuilder[] = [];

--- a/command_builder.test.ts
+++ b/command_builder.test.ts
@@ -2,9 +2,10 @@ import $ from "./mod.ts";
 import { assertEquals } from "./test_deps.ts";
 
 Deno.test("Quick example", async () => {
-  const stream = $`echo "abc\nabcde\nabcdef\nbcdefg"`
+  const stream = $`echo "abc\nabcde\nabcdef\nacddef\nbcdefg"`
     .map((l) => `bug : ${l}`)
     .$(`grep 'bug : a'`).noThrow()
+    .pipe($`grep 'bug : ab'`).noThrow()
     .filter((l) => l.length > "bug : ".length + 5);
   for await (const line of stream) {
     assertEquals(line, "bug : abcdef");

--- a/mod.ts
+++ b/mod.ts
@@ -11,6 +11,7 @@ declare module "./deps.ts" {
      * @returns A new command builder representing the piped command.
      */
     pipe(next: CommandBuilder): CommandBuilder;
+
     /**
      * Pipes the output of the current command into another command.
      * @param next - The command as a string to pipe into.
@@ -18,7 +19,6 @@ declare module "./deps.ts" {
      */
     $(next: string): CommandBuilder;
 
-    // The next methods are re-exports of LineStream methods
     /**
      * Creates a new line stream for reading the output of the command.
      * @returns The line stream.
@@ -58,7 +58,6 @@ CommandBuilder.prototype.$ = function (next: string) {
   return new CommandBuilder().command(next).stdin(p.stdout());
 };
 
-// The next methods are re-exports of LineStream methods
 CommandBuilder.prototype.lineStream = function () {
   return new LineStream(
     this.stdout("piped").spawn().stdout().pipeThrough(new TextDecoderStream())

--- a/mod.ts
+++ b/mod.ts
@@ -5,29 +5,65 @@ import { LineStream, XargsFunction } from "./LineStream/LineStream.ts";
 
 declare module "./deps.ts" {
   interface CommandBuilder {
-    pipe(): ReadableStream<Uint8Array>;
-    lineStream(): LineStream;
+    /**
+     * Pipes the output of the current command into another command.
+     * @param next - The command to pipe into.
+     * @returns A new command builder representing the piped command.
+     */
+    pipe(next: CommandBuilder): CommandBuilder;
+    /**
+     * Pipes the output of the current command into another command.
+     * @param next - The command as a string to pipe into.
+     * @returns A new command builder representing the piped command.
+     */
     $(next: string): CommandBuilder;
+
+    // The next methods are re-exports of LineStream methods
+    /**
+     * Creates a new line stream for reading the output of the command.
+     * @returns The line stream.
+     */
+    lineStream(): LineStream;
+
+    /**
+     * Maps the output of a function that returns a line stream, allowing further processing.
+     * @param mapFunction - The function to map the output.
+     * @returns The line stream resulting from the mapping operation.
+     */
     map(mapFunction: MapFunction<string, string>): LineStream;
+
+    /**
+     * Filters the output of a function that returns a line stream, allowing further processing.
+     * @param filterFunction - The function to filter the output.
+     * @returns The line stream resulting from the filtering operation.
+     */
     filter(filterFunction: FilterFunction<string>): LineStream;
+
+    /**
+     * Builds and executes command lines using the standard input.
+     * @param xargsFunction - The function that handles the execution of command lines.
+     * @returns A promise that resolves to an array of command builders representing the executed commands.
+     */
     xargs(xargsFunction: XargsFunction): Promise<CommandBuilder[]>;
   }
 }
 
-CommandBuilder.prototype.pipe = function () {
-  return this.stdout("piped").spawn().stdout();
-};
-
-CommandBuilder.prototype.lineStream = function () {
-  return new LineStream(
-    this.pipe().pipeThrough(new TextDecoderStream())
-      .pipeThrough(new TextLineStream()),
-  );
+CommandBuilder.prototype.pipe = function (next: CommandBuilder) {
+  const p = this.stdout("piped").spawn();
+  return next.stdin(p.stdout());
 };
 
 CommandBuilder.prototype.$ = function (next: string) {
   const p = this.stdout("piped").spawn();
   return new CommandBuilder().command(next).stdin(p.stdout());
+};
+
+// The next methods are re-exports of LineStream methods
+CommandBuilder.prototype.lineStream = function () {
+  return new LineStream(
+    this.stdout("piped").spawn().stdout().pipeThrough(new TextDecoderStream())
+      .pipeThrough(new TextLineStream()),
+  );
 };
 
 CommandBuilder.prototype.map = function (


### PR DESCRIPTION
(props to chatgpt for writing the docs)

couple of notes/questions:

- The old `pipe` method that was in CommandBuilder interface, seemd wrong: it was just being used internally as a helper, so I inlined it where its used, and replaced it with the appropriate code
- stdout seems to be hardcoded in many places, can we do better ?
- should CommandBuilder.prototype.pipe/$ wrap LineStream methods instead of having their own code (like the other functions)?