### PR TITLE
fix the example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@ A useful util library for writing shell script stream processing using
 ```typescript
 import $ from "https://raw.githubusercontent.com/impactaky/dax_extras/1.0.0/mod.ts";
 
-await $`echo "abc\nabcde\nabcdef\nbcdefg"`
+const commands = await $`echo "abc\nabcde\nabcdef\nbcdefg"`
   .map((l) => `bug : ${l}`)
   .$(`grep 'bug : a'`).noThrow()
   .filter((l) => l.length > "bug : ".length + 3)
   .xargs((l) => $`echo de${l}`);
+
+await Promise.all(commands);
 // => debug : abcde
 // => debug : abcdef
 ```


### PR DESCRIPTION
The example currently doesn't output anything, since xargs returns a Promise<CommandBuilder[]>, they need to be awaited to get an output

Maybe its a good idea to have a class `XargsReturn` that wraps Promise<CommndBuilder[]> and extends Promise, so it becomes await-able, and maybe its prints the output on await like CommandBuilder