### PR TITLE
add a common interface: Stream

### DIFF
--- a/LineStream/LineStream.test.ts
+++ b/LineStream/LineStream.test.ts
@@ -67,9 +67,10 @@ Deno.test("LineStream.xargs one-line", async () => {
 });
 
 Deno.test("LineStream.xargs multi-line", async () => {
-  const result = await $`echo "line1\nline2"`
+  const result = await $`echo "line1\nline2\nline3"`
     .lineStream()
     .xargs((input) => $`echo ${input} world`)
+    .pipe($`grep -v 3`)
     .lines();
   assertEquals(result, ["line1 world", "line2 world"]);
 });

--- a/LineStream/LineStream.ts
+++ b/LineStream/LineStream.ts
@@ -1,4 +1,5 @@
 import { CommandBuilder } from "../deps.ts";
+import { StreamInterface } from "./Stream.ts";
 
 import {
   ApplyFunction,
@@ -35,7 +36,7 @@ class LineToByteStream extends TransformStream<string, Uint8Array> {
  * Represents a stream of lines for reading the output of a command.
  * It implements an async iterator, allowing iteration over the lines.
  */
-export class LineStream {
+export class LineStream implements StreamInterface {
   #stream: ReadableStream;
 
   /**

--- a/LineStream/LineStream.ts
+++ b/LineStream/LineStream.ts
@@ -1,4 +1,5 @@
 import { CommandBuilder } from "../deps.ts";
+import { StreamInterface } from "./Stream.ts";
 
 import {
   ApplyFunction,
@@ -35,7 +36,7 @@ class LineToByteStream extends TransformStream<string, Uint8Array> {
  * Represents a stream of lines for reading the output of a command.
  * It implements an async iterator, allowing iteration over the lines.
  */
-export class LineStream {
+export class LineStream implements StreamInterface {
   #stream: ReadableStream;
 
   /**
@@ -116,6 +117,10 @@ export class LineStream {
    */
   $(next: string): CommandBuilder {
     return new CommandBuilder().command(next).stdin(this.byteStream());
+  }
+
+  lineStream(): LineStream {
+    return this;
   }
 
   /**

--- a/LineStream/Stream.ts
+++ b/LineStream/Stream.ts
@@ -4,11 +4,31 @@ import { ApplyFunction, FilterFunction, MapFunction } from "./Transformer.ts";
 import { XargsStream } from "./XargsStream.ts";
 
 export interface StreamInterface {
+  /**
+   * Async iterator implementation for iterating over the lines of the stream.
+   * @returns An async iterator for iterating over the lines of the stream.
+   */
   [Symbol.asyncIterator](): AsyncGenerator;
+
+  /**
+   * Reads the entire stream and returns the concatenated text.
+   * @returns A promise that resolves to the concatenated text.
+   */
   text(): Promise<string>;
+
+  /**
+   * Reads the entire stream and returns an array of lines.
+   * @returns A promise that resolves to an array of lines.
+   */
   lines(): Promise<string[]>;
+
   // TODO: should this be added ?
   // pipeThrough(transform: TransformStream): LineStreamInterface;
+
+  /**
+   * Get stream as Uint8Array
+   * @returns The encoded stream.
+   */
   byteStream(): ReadableStream<Uint8Array>;
 
   /**

--- a/LineStream/Stream.ts
+++ b/LineStream/Stream.ts
@@ -11,7 +11,6 @@ export interface StreamInterface {
   // pipeThrough(transform: TransformStream): LineStreamInterface;
   byteStream(): ReadableStream<Uint8Array>;
 
-
   /**
    * Pipes the output of the current command into another command.
    * @param next - The command to pipe into.

--- a/LineStream/Stream.ts
+++ b/LineStream/Stream.ts
@@ -1,0 +1,66 @@
+import { CommandBuilder } from "../deps.ts";
+import { LineStream, XargsFunction } from "./LineStream.ts";
+import { ApplyFunction, FilterFunction, MapFunction } from "./Transformer.ts";
+import { XargsStream } from "./XargsStream.ts";
+
+export interface StreamInterface {
+  [Symbol.asyncIterator](): AsyncGenerator;
+  text(): Promise<string>;
+  lines(): Promise<string[]>;
+  // TODO: should this be added ?
+  // pipeThrough(transform: TransformStream): LineStreamInterface;
+  byteStream(): ReadableStream<Uint8Array>;
+
+  /**
+   * Pipes the output of the current command into another command.
+   * @param next - The command to pipe into.
+   * @returns A new command builder representing the piped command.
+   */
+  pipe(next: CommandBuilder): CommandBuilder;
+
+  /**
+   * Pipes the output of the current command into another command.
+   * @param next - The command as a string to pipe into.
+   * @returns A new command builder representing the piped command.
+   */
+  $(next: string): CommandBuilder;
+
+  /**
+   * Creates a new line stream for reading the output of the command.
+   * @returns The line stream.
+   */
+  lineStream(): LineStream;
+
+  /**
+   * Maps the output of a function that returns a line stream, allowing further processing.
+   * @param mapFunction - The function to map the output.
+   * @returns The line stream resulting from the mapping operation.
+   */
+  map(mapFunction: MapFunction<string, string>): LineStream;
+
+  /**
+   * Filters the output of a function that returns a line stream, allowing further processing.
+   * @param filterFunction - The function to filter the output.
+   * @returns The line stream resulting from the filtering operation.
+   */
+  filter(filterFunction: FilterFunction<string>): LineStream;
+
+  /**
+   * Builds and executes command lines using the standard input.
+   * @param xargsFunction - The function that handles the execution of command lines.
+   * @returns A promise that resolves to an array of command builders representing the executed commands.
+   */
+  xargs(xargsFunction: XargsFunction): XargsStream;
+
+  /**
+   * Applies a given function to the stream, transforming each item of the stream
+   * as specified by the function. The function may return a transformed item, an array of transformed items, or `undefined`.
+   * When a transformed item or an array of items is returned, it/they are enqueued to the output stream.
+   * If `undefined` is returned, the item is ignored and not included in the output stream.
+   * @param applyFunction - A function to be applied to each item in the stream.
+   * This function takes an item of type `T`, and returns either a transformed item of type `U`,
+   * `U[]`, or `undefined`.
+   * @returns A new `ReadableStream` instance that will contain the transformed items.
+   */
+  apply(applyFunction: ApplyFunction<string, string>): LineStream;
+}

--- a/LineStream/Stream.ts
+++ b/LineStream/Stream.ts
@@ -1,0 +1,19 @@
+import { CommandBuilder } from "../deps.ts";
+import { XargsFunction } from "./LineStream.ts";
+import { ApplyFunction, FilterFunction, MapFunction } from "./Transformer.ts";
+import { XargsStream } from "./XargsStream.ts";
+
+export interface StreamInterface {
+  [Symbol.asyncIterator](): AsyncGenerator;
+  text(): Promise<string>;
+  lines(): Promise<string[]>;
+  // TODO: should this be added ?
+  // pipeThrough(transform: TransformStream): LineStreamInterface;
+  byteStream(): ReadableStream<Uint8Array>;
+  pipe(next: CommandBuilder): CommandBuilder;
+  $(next: string): CommandBuilder;
+  map(mapFunction: MapFunction<string, string>): StreamInterface;
+  filter(filterFunction: FilterFunction<string>): StreamInterface;
+  xargs(xargsFunction: XargsFunction): XargsStream;
+  apply(applyFunction: ApplyFunction<string, string>): StreamInterface;
+}

--- a/LineStream/XargsStream.ts
+++ b/LineStream/XargsStream.ts
@@ -30,6 +30,7 @@ export class XargsStream
       const ret: CommandResult[] = [];
       for await (const builder of this.#stream) {
         // typescript bug: builder is CommandBuilder not CommandResult
+        // https://github.com/microsoft/TypeScript/issues/47593
         ret.push(await (builder as unknown as CommandBuilder));
       }
       return ret;

--- a/LineStream/XargsStream.ts
+++ b/LineStream/XargsStream.ts
@@ -45,10 +45,6 @@ export class XargsStream
     this.#stream = stream;
   }
 
-  /**
-   * Async iterator implementation for iterating over the CommandBuilders of the stream.
-   * @returns An async iterator for iterating over the CommandBuilders of the stream.
-   */
   async *[Symbol.asyncIterator]() {
     const reader = this.#stream.getReader();
     while (true) {
@@ -58,26 +54,14 @@ export class XargsStream
     }
   }
 
-  /**
-   * Reads the entire stream and returns the concatenated text.
-   * @returns A promise that resolves to the concatenated text.
-   */
   text() {
     return this.lineStream().text();
   }
 
-  /**
-   * Reads the entire stream and returns an array of lines.
-   * @returns A promise that resolves to an array of lines.
-   */
   lines() {
     return this.lineStream().lines();
   }
 
-  /**
-   * Creates a new byte stream for reading the output of the xargs.
-   * @returns The byte stream.
-   */
   byteStream(): ReadableStream<Uint8Array> {
     return this.#stream.pipeThrough(toTransformStream(async function* (src) {
       for await (const builder of src) {
@@ -89,30 +73,16 @@ export class XargsStream
     }));
   }
 
-  /**
-   * Pipes the output of the current command into another command.
-   * @param next - The CommandBuilder representing the next command.
-   * @returns A new command builder representing the piped command.
-   */
   pipe(next: CommandBuilder): CommandBuilder {
     const pipedStream = this.byteStream();
     return next.stdin(pipedStream);
   }
 
-  /**
-   * Pipes the output of the current command into another command.
-   * @param next - The command as a string to pipe into.
-   * @returns A new command builder representing the piped command.
-   */
   $(next: string): CommandBuilder {
     const pipedStream = this.byteStream();
     return new CommandBuilder().command(next).stdin(pipedStream);
   }
 
-  /**
-   * Creates a new line stream for reading the output of the xargs.
-   * @returns The line stream.
-   */
   lineStream(): LineStream {
     return new LineStream(
       this.byteStream()
@@ -121,49 +91,24 @@ export class XargsStream
     );
   }
 
-  /**
-   * Maps the output of a function that returns a line stream, allowing further processing.
-   * @param mapFunction - The function to map the output.
-   * @returns The line stream resulting from the mapping operation.
-   */
   map(
     mapFunction: MapFunction<string, string>,
   ) {
     return this.lineStream().map(mapFunction);
   }
 
-  /**
-   * Filters the output of a function that returns a line stream, allowing further processing.
-   * @param filterFunction - The function to filter the output.
-   * @returns The line stream resulting from the filtering operation.
-   */
   filter(
     filterFunction: FilterFunction<string>,
   ) {
     return this.lineStream().filter(filterFunction);
   }
 
-  /**
-   * Create a CommandBuilder for each line of the stream using the provided xargs function.
-   * @param xargsFunction - The xargs function that handles the execution of command lines.
-   * @returns A readable stream of CommandBuilder.
-   */
   xargs(
     xargsFunction: XargsFunction,
   ) {
     return this.lineStream().xargs(xargsFunction);
   }
 
-  /**
-   * Applies a given function to the stream, transforming each item of the stream
-   * as specified by the function. The function may return a transformed item, an array of transformed items, or `undefined`.
-   * When a transformed item or an array of items is returned, it/they are enqueued to the output stream.
-   * If `undefined` is returned, the item is ignored and not included in the output stream.
-   * @param applyFunction - A function to be applied to each item in the stream.
-   * This function takes an item of type `T`, and returns either a transformed item of type `U`,
-   * `U[]`, or `undefined`.
-   * @returns A new `ReadableStream` instance that will contain the transformed items.
-   */
   apply(
     applyFunction: ApplyFunction<string, string>,
   ) {

--- a/mod.ts
+++ b/mod.ts
@@ -6,63 +6,11 @@ import {
   MapFunction,
 } from "./LineStream/Transformer.ts";
 import { LineStream, XargsFunction } from "./LineStream/LineStream.ts";
-import { XargsStream } from "./LineStream/XargsStream.ts";
+import { StreamInterface } from "./LineStream/Stream.ts";
 
 declare module "./deps.ts" {
-  interface CommandBuilder {
-    /**
-     * Pipes the output of the current command into another command.
-     * @param next - The command to pipe into.
-     * @returns A new command builder representing the piped command.
-     */
-    pipe(next: CommandBuilder): CommandBuilder;
-
-    /**
-     * Pipes the output of the current command into another command.
-     * @param next - The command as a string to pipe into.
-     * @returns A new command builder representing the piped command.
-     */
-    $(next: string): CommandBuilder;
-
-    /**
-     * Creates a new line stream for reading the output of the command.
-     * @returns The line stream.
-     */
-    lineStream(): LineStream;
-
-    /**
-     * Maps the output of a function that returns a line stream, allowing further processing.
-     * @param mapFunction - The function to map the output.
-     * @returns The line stream resulting from the mapping operation.
-     */
-    map(mapFunction: MapFunction<string, string>): LineStream;
-
-    /**
-     * Filters the output of a function that returns a line stream, allowing further processing.
-     * @param filterFunction - The function to filter the output.
-     * @returns The line stream resulting from the filtering operation.
-     */
-    filter(filterFunction: FilterFunction<string>): LineStream;
-
-    /**
-     * Builds and executes command lines using the standard input.
-     * @param xargsFunction - The function that handles the execution of command lines.
-     * @returns A promise that resolves to an array of command builders representing the executed commands.
-     */
-    xargs(xargsFunction: XargsFunction): XargsStream;
-
-    /**
-     * Applies a given function to the stream, transforming each item of the stream
-     * as specified by the function. The function may return a transformed item, an array of transformed items, or `undefined`.
-     * When a transformed item or an array of items is returned, it/they are enqueued to the output stream.
-     * If `undefined` is returned, the item is ignored and not included in the output stream.
-     * @param applyFunction - A function to be applied to each item in the stream.
-     * This function takes an item of type `T`, and returns either a transformed item of type `U`,
-     * `U[]`, or `undefined`.
-     * @returns A new `ReadableStream` instance that will contain the transformed items.
-     */
-    apply(applyFunction: ApplyFunction<string, string>): LineStream;
-  }
+  // deno-lint-ignore no-empty-interface
+  interface CommandBuilder extends StreamInterface {}
 }
 
 CommandBuilder.prototype.pipe = function (next: CommandBuilder) {


### PR DESCRIPTION
I'm trying out the common interface idea, not sure how good is this, the advantage is the compiler does warn if the interface is not implemented correctly, so any new method added to a Stream Class should be detected, also future stream classes can be implemented correctly

couple of notes:
- the diff is messed up because I reorganized Xargsstream methods to have the same order as LineStream
- <del>the comments can be all yanked to interface if they're the same</del> done
- <del>I tried declaring CommandBuilder extends StreamInterface, but I didn't like the result, I get 0 info from the compiler by adding this, so I think its not worth it</del> see below