### PR TITLE
docs: update alternate import method

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,7 @@ You can import dax_extras like this.
 
 ```typescript
 import $ from "https://deno.land/x/dax@0.32.0/mod.ts";
-import "https://raw.githubusercontent.com/impactaky/dax_extras/1.0.0/mod.ts";
+// the dax version used internally by dax extras is at the suffix
+// it **must** match the dax version used
+import "https://deno.land/x/dax_extras@2.2.0-0.32.0/mod.ts";
 ```


### PR DESCRIPTION
Implements https://github.com/impactaky/dax_extras/issues/2#issuecomment-1620274572

Requires that you push a new tag `2.2.0-0.32.0`

Pros:
- feels intuitive, its more obvious that we're extending dax not a different library
- theoretically this approach allows the user to use other libraries that also extend dax, at the same time

Cons:
- nothing comes to mind