### PR TITLE
use async varientes of Deno apis

### DIFF
--- a/LineStream/LineStream.test.ts
+++ b/LineStream/LineStream.test.ts
@@ -16,11 +16,10 @@ Deno.test("LineStram.lines", async () => {
 
 Deno.test("LineStream.toFile", async () => {
   const path = $.path(await Deno.makeTempFile());
-  path.writeText("foo");
+  await path.writeText("foo");
   await $`echo "line1\nline2"`
     .lineStream().toFile(path);
   const text = path.readTextSync();
-  console.log(text);
   assertEquals(text, "line1\nline2\n");
 });
 

--- a/LineStream/LineStream.ts
+++ b/LineStream/LineStream.ts
@@ -75,7 +75,7 @@ export class LineStream implements StreamInterface {
   async toFile(path: PathRef): Promise<void> {
     const file = await path.open({ write: true });
     for await (const line of this.#stream) {
-      file.writeTextSync(line + "\n");
+      await file.writeText(line + "\n");
     }
     file.close();
   }

--- a/LineStream/XargsStream.ts
+++ b/LineStream/XargsStream.ts
@@ -68,7 +68,7 @@ export class XargsStream
     const pipedStream = this.byteStream();
     const file = await path.open({ write: true });
     for await (const bytes of pipedStream) {
-      file.writeSync(bytes);
+      await file.write(bytes);
     }
     file.close();
   }

--- a/mod.ts
+++ b/mod.ts
@@ -14,7 +14,7 @@ declare module "./deps.ts" {
 }
 
 CommandBuilder.prototype.toFile = async function (path: PathRef) {
-  path.writeSync(await this.bytes());
+  await path.write(await this.bytes());
 };
 
 CommandBuilder.prototype.pipe = function (next: CommandBuilder) {


### PR DESCRIPTION
Its not recommended to use sync functions inside async functions especially as a library, because this blocks deno event loop and stops other async tasks from making progress

for more info see https://github.com/denoland/deno_lint/issues/1177 https://github.com/denoland/deno_lint/pull/1178